### PR TITLE
Add optional SSL context to Relay and RelayManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,21 @@ print(f"Public key: {public_key.bech32()}")
 
 **Connect to relays**
 
+An optional `ssl_context` parameter can be provided to `add_relay` to customize
+TLS settings.
+
 ```python
+import ssl
 from pynostr.relay_manager import RelayManager
 from pynostr.filters import FiltersList, Filters
 from pynostr.event import EventKind
 import time
 import uuid
 
+ctx = ssl.create_default_context()
 relay_manager = RelayManager(timeout=2)
-relay_manager.add_relay("wss://nostr-pub.wellorder.net")
-relay_manager.add_relay("wss://relay.damus.io")
+relay_manager.add_relay("wss://nostr-pub.wellorder.net", ssl_context=ctx)
+relay_manager.add_relay("wss://relay.damus.io", ssl_context=ctx)
 filters = FiltersList([Filters(kinds=[EventKind.TEXT_NOTE], limit=100)])
 subscription_id = uuid.uuid1().hex
 relay_manager.add_subscription_on_all_relays(subscription_id, filters)

--- a/pynostr/relay.py
+++ b/pynostr/relay.py
@@ -1,4 +1,5 @@
 import logging
+import ssl
 from typing import Optional
 
 from tornado import gen
@@ -22,6 +23,7 @@ class Relay(BaseRelay):
         close_on_eose: bool = True,
         message_callback=None,
         message_callback_url=False,
+        ssl_options: Optional[ssl.SSLContext] = None,
     ) -> None:
         if policy is None:
             policy = RelayPolicy()
@@ -37,6 +39,7 @@ class Relay(BaseRelay):
         self.ws = None
         self.io_loop = io_loop
         self.running = True
+        self.ssl_options = ssl_options
 
     @property
     def is_connected(self) -> bool:
@@ -56,6 +59,7 @@ class Relay(BaseRelay):
                         self.url,
                         ping_interval=60,
                         ping_timeout=120,
+                        ssl_options=self.ssl_options,
                     ),
                 )
             else:
@@ -63,6 +67,7 @@ class Relay(BaseRelay):
                     self.url,
                     ping_interval=60,
                     ping_timeout=120,
+                    ssl_options=self.ssl_options,
                 )
             self.connected = True
             # self.io_loop.call_later(1, self.send_message, self.request)

--- a/pynostr/relay_manager.py
+++ b/pynostr/relay_manager.py
@@ -3,6 +3,7 @@ import logging
 import time
 from dataclasses import dataclass
 from typing import Optional
+import ssl
 
 from tornado import gen
 from tornado.ioloop import IOLoop
@@ -44,6 +45,7 @@ class RelayManager:
         message_callback=None,
         message_callback_url=False,
         get_metadata=False,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         if policy is None:
             policy = RelayPolicy()
@@ -56,6 +58,7 @@ class RelayManager:
             close_on_eose=close_on_eose,
             message_callback=message_callback,
             message_callback_url=message_callback_url,
+            ssl_options=ssl_context,
         )
 
         if self.error_threshold is not None:
@@ -81,6 +84,7 @@ class RelayManager:
         message_callback=None,
         message_callback_url=False,
         get_metadata=False,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         for relay in relay_list:
             self.add_relay(
@@ -91,6 +95,7 @@ class RelayManager:
                 message_callback=message_callback,
                 message_callback_url=message_callback_url,
                 get_metadata=get_metadata,
+                ssl_context=ssl_context,
             )
 
     def remove_closed_relays(self):

--- a/tests/test_relay_manager.py
+++ b/tests/test_relay_manager.py
@@ -1,5 +1,6 @@
 """Forked from https://github.com/jeffthibault/python-nostr.git."""
 
+import ssl
 import unittest
 
 from pynostr.event import Event
@@ -51,4 +52,13 @@ class TestPrivateKey(unittest.TestCase):
             test_subscription.id
             not in relay_manager.relays["ws://fake-relay2"].subscriptions.keys()
         )
+        relay_manager.close_all_relay_connections()
+
+
+class TestRelayManagerSSLContext(unittest.TestCase):
+    def test_add_relay_ssl_context(self):
+        ctx = ssl.create_default_context()
+        relay_manager = RelayManager()
+        relay_manager.add_relay(url="ws://fake-relay", ssl_context=ctx)
+        self.assertIs(relay_manager.relays["ws://fake-relay"].ssl_options, ctx)
         relay_manager.close_all_relay_connections()


### PR DESCRIPTION
## Summary
- allow RelayManager.add_relay to pass an ssl_context to Relay
- let Relay accept ssl_options and forward to websocket_connect
- document ssl_context usage and test it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e3f0311c8331ae097fbc230b1c1f