### PR TITLE
Use HTTPRequest for relay connections

### DIFF
--- a/pynostr/relay.py
+++ b/pynostr/relay.py
@@ -3,6 +3,7 @@ import ssl
 from typing import Optional
 
 from tornado import gen
+from tornado.httpclient import HTTPRequest
 from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketError, websocket_connect
 
@@ -52,22 +53,23 @@ class Relay(BaseRelay):
         self.error_counter = 0
         self.timeout_error_counter = 0
         try:
+            request = HTTPRequest(
+                self.url, ssl_options=self.ssl_options, connect_timeout=self.timeout
+            )
             if self.timeout > 0:
                 self.ws = yield gen.with_timeout(
                     self.io_loop.time() + self.timeout,
                     websocket_connect(
-                        self.url,
+                        request,
                         ping_interval=60,
                         ping_timeout=120,
-                        ssl_options=self.ssl_options,
                     ),
                 )
             else:
                 self.ws = yield websocket_connect(
-                    self.url,
+                    request,
                     ping_interval=60,
                     ping_timeout=120,
-                    ssl_options=self.ssl_options,
                 )
             self.connected = True
             # self.io_loop.call_later(1, self.send_message, self.request)


### PR DESCRIPTION
## Summary
- Build `HTTPRequest` objects with SSL context and timeout when connecting to relays
- Test that `websocket_connect` receives the provided SSL context through the `HTTPRequest`

## Testing
- `pre-commit run --files pynostr/relay.py tests/test_relay_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e53ea26c8331bbff86337b6abe70